### PR TITLE
Add structured subagent task payloads

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -6,3 +6,5 @@ Use this log to capture documentation updates performed during the migration. Ea
 | --- | --- | --- | --- |
 | _YYYY-MM-DD_ | _Name_ | `docs/example.md` | Brief note about the update |
 | 2025-10-07 | Coordination | `docs/migration.md`, `docs/README.md` | Added Codex subagent launch templates and updated doc index |
+| 2025-10-07 | Coordination | `docs/migration-task-tracker.md`, `docs/change-log.md` | Added migration task tracker checklist for Codex subagents |
+| 2025-10-07 | Coordination | `docs/migration-tasks.yaml`, `docs/migration-task-tracker.md` | Added structured subagent task payloads and linked tracker usage |

--- a/docs/migration-task-tracker.md
+++ b/docs/migration-task-tracker.md
@@ -1,0 +1,73 @@
+# Migration Task Tracker
+
+Structured task list derived from the migration roadmap so subagents can be dispatched directly from this repository.
+
+## Usage
+- Locate the next available unchecked task in the index.
+- Reference `docs/migration-tasks.yaml` for ready-to-send payloads when opening a Codex subagent request.
+- Update the checkbox, notes, and YAML `status` once the task is assigned or delivered.
+
+## Task Index
+
+### Governance & Foundations
+- [ ] **MIG-000 Pre-flight Governance**  
+  _Prerequisites:_ None  
+  _Summary:_ Spin up the long-lived `migration` branch, enforce documentation-first workflow, and verify GitHub Pages preview configuration.  
+  _Deliverables:_ Branching plan, doc update checklist, preview validation notes.
+
+- [ ] **MIG-D0 Documentation Vanguard**  
+  _Prerequisites:_ MIG-000  
+  _Summary:_ Sweep the entire `/docs` tree, log stale sections, and capture parity acceptance criteria plus regression test inventory in `docs/change-log.md`.  
+  _Deliverables:_ Updated docs, parity checklist, regression inventory, change-log entry.
+
+### Planning & Scaffold
+- [ ] **MIG-P1 Planning & Tooling**  
+  _Prerequisites:_ MIG-D0 sign-off  
+  _Summary:_ Document target stack adjustments, outline linting/formatting automation (ESLint, Prettier, Stylelint), configure lint-staged + husky, and plan CI preview workflows.  
+  _Deliverables:_ Tooling implementation notes, updated architecture/development docs, automation checklist.
+
+- [ ] **MIG-S2 Stack Scaffold**  
+  _Prerequisites:_ MIG-P1 merged  
+  _Summary:_ Bootstrap the Vite + React + TypeScript workspace (`apps/web`, `packages/ui`, `packages/design-tokens`), wire strict TS, Vitest, PostCSS, and `vite-plugin-pwa`, and refresh diagrams.  
+  _Deliverables:_ Scaffold plan, updated architecture diagrams, validation checklist.
+
+### Core Systems & UI
+- [ ] **MIG-S3 Core Domain Services**  
+  _Prerequisites:_ MIG-S2 available  
+  _Summary:_ Port storage, event bus, theming, audio, AI provider, and analytics into typed modules with dependency injection and observability hooks.  
+  _Deliverables:_ Service modernization blueprint, updated service/event docs, verification checklist.
+
+- [ ] **MIG-UI4 UI Library Extraction**  
+  _Prerequisites:_ MIG-S3 service contracts, MIG-S2 design tokens  
+  _Summary:_ Build `/packages/ui` with shared design tokens, Storybook/Ladle setup, accessibility/visual tests, and publishing pipeline notes.  
+  _Deliverables:_ Component library plan, accessibility/testing strategy, publishing outline.
+
+- [ ] **MIG-APP5 Application Shell & Features**  
+  _Prerequisites:_ MIG-UI4 alpha library, MIG-S3 services  
+  _Summary:_ Recreate React app shell, migrate task CRUD, filters, achievements, quotes, AI flows, and integrate shared services/components with Zustand/React Query.  
+  _Deliverables:_ Feature migration playbook, parity notes, accessibility/regression checklist.
+
+### Styling, QA, Data, Release
+- [ ] **MIG-CSS6 Styling Modernization**  
+  _Prerequisites:_ MIG-APP5 shell + design tokens  
+  _Summary:_ Replace legacy CSS with token-driven theming, optimize assets, and document multi-theme support with performance audits.  
+  _Deliverables:_ Styling migration plan, updated UI/CSS docs, performance audit checklist.
+
+- [ ] **MIG-QA7 Testing & Quality Gates**  
+  _Prerequisites:_ MIG-APP5 functionality, MIG-CSS6 styling guidance  
+  _Summary:_ Author Vitest, Testing Library, and Playwright suites; configure CI pipelines for lint/test/build/storybook/visual checks; refresh QA documentation.  
+  _Deliverables:_ Test plan, CI guardrail checklist, updated QA docs.
+
+- [ ] **MIG-DATA8 Data Migration & Compatibility**  
+  _Prerequisites:_ MIG-S3 services, MIG-APP5 app shell  
+  _Summary:_ Document schemas, implement typed migration scripts for legacy storage, ensure backward compatibility, and establish telemetry/monitoring.  
+  _Deliverables:_ Data migration blueprint, compatibility matrix, rollback/monitoring notes.
+
+- [ ] **MIG-RELEASE9 Documentation & Release**  
+  _Prerequisites:_ Completion of prior tasks  
+  _Summary:_ Compile release notes, finalize documentation bundle, publish UI package assets, coordinate final QA sign-off, and script `migration` → `main` merge with rollback plan.  
+  _Deliverables:_ Release readiness checklist, final documentation audit, publishing artifacts.
+
+## Notes & Status Updates
+- Use `docs/change-log.md` to record when each task is dispatched or completed.
+- Append any clarifications, blockers, or cross-phase dependencies below.

--- a/docs/migration-tasks.yaml
+++ b/docs/migration-tasks.yaml
@@ -1,0 +1,202 @@
+# Task definitions for Codex subagents executing the migration roadmap.
+# Each entry contains the payload required to spin up an automation task.
+tasks:
+  - id: MIG-000
+    title: "Migration – Pre-flight Governance"
+    phase: "Governance & Foundations"
+    prerequisites: []
+    objective: >-
+      Establish the long-lived migration branch, enforce documentation-first guardrails,
+      and verify preview infrastructure before implementation work begins.
+    steps:
+      - Create the long-lived `migration` branch and document the branching model.
+      - Audit documentation expectations and confirm review requirements for downstream phases.
+      - Verify GitHub Pages preview configuration and capture QA validation notes.
+    deliverables:
+      - Branching and review plan recorded in repository docs.
+      - Documentation-first checklist for migration contributors.
+      - Preview validation summary and outstanding risks.
+    status: todo
+  - id: MIG-D0
+    title: "Migration – Documentation Vanguard"
+    phase: "Governance & Foundations"
+    prerequisites:
+      - MIG-000
+    objective: >-
+      Refresh every document in the `docs/` tree, capture parity acceptance criteria,
+      and assemble a regression inventory for later phases.
+    steps:
+      - Sweep the entire documentation index and note stale or missing sections.
+      - Update affected files and record edits plus open questions in `docs/change-log.md`.
+      - Extract parity requirements, data expectations, and regression test checklists.
+    deliverables:
+      - Updated documentation set with logged edits.
+      - Parity acceptance and regression inventories.
+      - Approval note signalling documentation readiness.
+    status: todo
+  - id: MIG-P1
+    title: "Migration – Planning & Tooling"
+    phase: "Planning & Scaffold"
+    prerequisites:
+      - MIG-D0
+    objective: >-
+      Document the target stack updates and introduce linting, formatting, and automation
+      tooling (ESLint, Prettier, Stylelint, lint-staged, husky, dependency bots).
+    steps:
+      - Revisit `docs/architecture.md` and `docs/development.md` to align on the target stack.
+      - Draft the linting/formatting and automation rollout plan.
+      - Document CI preview workflows and dependency update strategy.
+    deliverables:
+      - Tooling implementation plan with sequencing.
+      - Updated architecture/development docs reflecting tooling expectations.
+      - Automation checklist for lint-staged, husky, and dependency bots.
+    status: todo
+  - id: MIG-S2
+    title: "Migration – Stack Scaffold"
+    phase: "Planning & Scaffold"
+    prerequisites:
+      - MIG-P1
+    objective: >-
+      Bootstrap the Vite + React + TypeScript workspace, supporting packages, and core tooling
+      (strict TS, Vitest, PostCSS, vite-plugin-pwa) backed by refreshed diagrams.
+    steps:
+      - Confirm architecture diagrams and component boundaries in `docs/architecture.md` and `docs/ui-map.md`.
+      - Lay out the folder structure for `apps/web`, `packages/ui`, and `packages/design-tokens`.
+      - Specify configuration details for TypeScript, Vitest, PostCSS, and PWA integration.
+    deliverables:
+      - Scaffold plan covering structure and configuration tasks.
+      - Updated diagrams and documentation references.
+      - Validation checklist for the scaffold implementation.
+    status: todo
+  - id: MIG-S3
+    title: "Migration – Core Domain Services"
+    phase: "Core Systems & UI"
+    prerequisites:
+      - MIG-S2
+    objective: >-
+      Port storage, event bus, theming, audio, AI provider, and analytics utilities into
+      typed, dependency-injection-friendly modules with observability hooks.
+    steps:
+      - Review service diagrams and event payload notes from documentation refresh.
+      - Design the target module structure and dependency injection approach.
+      - Plan observability hooks and compatibility checks for each service.
+    deliverables:
+      - Service modernization blueprint with responsibilities and interfaces.
+      - Updated service and event documentation.
+      - Testing and verification checklist for the service layer.
+    status: todo
+  - id: MIG-UI4
+    title: "Migration – UI Library Extraction"
+    phase: "Core Systems & UI"
+    prerequisites:
+      - MIG-S3
+      - MIG-S2
+    objective: >-
+      Build the reusable `/packages/ui` library backed by shared design tokens, documentation,
+      and accessibility/visual testing guardrails.
+    steps:
+      - Validate component taxonomy and accessibility requirements in `docs/ui-map.md`.
+      - Outline Storybook/Ladle setup, build tooling, and testing strategy.
+      - Document token integration across the component package.
+    deliverables:
+      - Implementation plan for the UI package.
+      - Accessibility and visual testing approach.
+      - Publishing pipeline outline and documentation updates.
+    status: todo
+  - id: MIG-APP5
+    title: "Migration – Application Shell & Features"
+    phase: "Core Systems & UI"
+    prerequisites:
+      - MIG-UI4
+      - MIG-S3
+    objective: >-
+      Rebuild the React application shell and migrate feature slices (tasks, filters, achievements,
+      quotes, AI flows) leveraging shared services and state management.
+    steps:
+      - Reconfirm parity requirements and state diagrams in `docs/product.md` and `docs/architecture.md`.
+      - Plan provider setup, routing, and state integration (Zustand, React Query).
+      - Sequence feature migration with parity validation for each slice.
+    deliverables:
+      - Migration playbook for shell and features.
+      - Documentation updates for new React flows and data handling.
+      - Accessibility, responsiveness, and regression checklist per feature.
+    status: todo
+  - id: MIG-CSS6
+    title: "Migration – Styling Modernization"
+    phase: "Styling, QA, Data, Release"
+    prerequisites:
+      - MIG-APP5
+      - MIG-S2
+    objective: >-
+      Replace legacy CSS with token-driven theming, optimized assets, and documented multi-theme
+      support while maintaining performance budgets.
+    steps:
+      - Review `docs/ui-css.md` for updated token definitions and theming strategy.
+      - Map legacy styles to new token-based equivalents and plan asset optimizations.
+      - Define performance audits (Lighthouse, bundle analysis) and documentation updates.
+    deliverables:
+      - Styling migration plan with file-level actions.
+      - Updated UI/CSS documentation and theming notes.
+      - Performance audit checklist and findings log.
+    status: todo
+  - id: MIG-QA7
+    title: "Migration – Testing & Quality Gates"
+    phase: "Styling, QA, Data, Release"
+    prerequisites:
+      - MIG-APP5
+      - MIG-CSS6
+    objective: >-
+      Deliver automated coverage (Vitest, Testing Library, Playwright) and CI pipelines covering lint,
+      test, build, storybook, and visual checks with refreshed QA documentation.
+    steps:
+      - Review `docs/qa-walk.md` and parity checklists to prioritize flows.
+      - Design the testing pyramid and outline suite ownership.
+      - Map required CI pipeline updates and validation strategy.
+    deliverables:
+      - Comprehensive test plan with tooling details.
+      - Documentation updates describing coverage expectations.
+      - CI guardrail checklist and rollout steps.
+    status: todo
+  - id: MIG-DATA8
+    title: "Migration – Data Migration & Compatibility"
+    phase: "Styling, QA, Data, Release"
+    prerequisites:
+      - MIG-S3
+      - MIG-APP5
+    objective: >-
+      Provide typed migration scripts for legacy data, ensure backward compatibility, and capture
+      telemetry/monitoring plus rollback procedures.
+    steps:
+      - Review documented data schemas and persistence edge cases.
+      - Plan migration scripts, fallback loaders, and telemetry requirements.
+      - Schedule validation across browsers and offline modes with rollback strategy.
+    deliverables:
+      - Data migration blueprint with testing scenarios.
+      - Documentation updates for schemas, compatibility matrix, and rollback procedures.
+      - Monitoring plan covering alerts and success metrics.
+    status: todo
+  - id: MIG-RELEASE9
+    title: "Migration – Documentation & Release"
+    phase: "Styling, QA, Data, Release"
+    prerequisites:
+      - MIG-D0
+      - MIG-P1
+      - MIG-S2
+      - MIG-S3
+      - MIG-UI4
+      - MIG-APP5
+      - MIG-CSS6
+      - MIG-QA7
+      - MIG-DATA8
+    objective: >-
+      Coordinate final release activities, ensuring documentation completeness, publishing assets,
+      QA sign-off, and the merge from `migration` to `main` with rollback contingencies.
+    steps:
+      - Verify all prior phase deliverables and documentation updates are recorded.
+      - Compile release notes, UI package publishing steps, and QA approval requirements.
+      - Outline the merge and rollback plan for promoting the migration branch.
+    deliverables:
+      - Release orchestration checklist with owners and timelines.
+      - Final documentation audit report and cross-link updates.
+      - Publish-ready artifacts for the UI package and release notes.
+    status: todo


### PR DESCRIPTION
## Summary
- add `docs/migration-tasks.yaml` containing ready-to-run Codex subagent task payloads
- link the migration tracker to the YAML definitions and clarify update steps
- log the new resource in the documentation change log for traceability

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e52c9eacf0832b8f6401ae36b9f1df